### PR TITLE
Update sending-transactions.md

### DIFF
--- a/docs/wallets/metamask/sending-transactions.md
+++ b/docs/wallets/metamask/sending-transactions.md
@@ -3,24 +3,24 @@ title: Sending SHM
 sidebar_position: 6
 ---
 
-## Sending a Basic Transaction
+## Sending a Transaction
 
-1, To send a transaction on MetaMask, click on Send button.
+1, To send a transaction on MetaMask, click on the "Send" button.
 
 ![sending_transactions_1](/img/sending_transactions/sending_transactions_1.jpg)
 
-2, Paste the destination address starting with 0x, fill the amount you want to send, click on Next.
+2, Paste the destination address starting with 0x, fill in the amount you want to send, click on "Next".
 
 ![sending_transactions_3](/img/sending_transactions/sending_transactions_3.jpg)
 
-3, Set the Gas Price and Gas Limit, click on Next.
+3, Set the "Gas Price" and "Gas Limit", click on "Next".
 
 ![sending_transactions_2](/img/sending_transactions/sending_transactions_2.jpg)
 
-4, Click on Confirm.
+4, Click on "Confirm".
 
 ![sending_transactions_4](/img/sending_transactions/sending_transactions_4.jpg)
 
-5, Once the transaction is complete, it will show up in MetaMask.
+5, Once the transaction is complete, it will show up in the "Activity" tab on MetaMask.
 
 ![sending_transactions_5](/img/sending_transactions/sending_transactions_5.jpg)


### PR DESCRIPTION
Applied changes:
-The subheading here uses the term “Basic Transaction” her which would imply there’s an advanced transaction. “Basic” should be removed here so it just reads as ‘Sending a Transaction’ which is what this section is teaching the reader.
- “Click on Send button” is grammatically incorrect this should be replaced with “click on the Send button”
- “fill the” should be replaced with “fill in the” in this context.
- On step 5 is states “once the transaction is complete, it will show up in MetaMask”. It would be best to clarify where exactly this would show up within MetaMask. Mentioned the "Activity" tab. 
- Added quotation marks when referring to a specific button or section